### PR TITLE
feat: add today marking feature

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -4,9 +4,18 @@ import "time"
 
 // Task represents a single task stored in the database.
 type Task struct {
-	ID        int
-	Title     string
-	Completed bool
-	ParentID  *int
-	CreatedAt time.Time
+	ID          int
+	Title       string
+	Completed   bool
+	ParentID    *int
+	CreatedAt   time.Time
+	ScheduledOn *string
+}
+
+// IsToday returns true if the task is scheduled for today.
+func (t Task) IsToday() bool {
+	if t.ScheduledOn == nil {
+		return false
+	}
+	return *t.ScheduledOn == time.Now().Format("2006-01-02")
 }

--- a/internal/ui/item.go
+++ b/internal/ui/item.go
@@ -20,7 +20,11 @@ func (i TaskItem) Title() string {
 	if i.Task.Completed {
 		check = "[x]"
 	}
-	return fmt.Sprintf("%s%s %s  created_at: %s", i.Prefix, check, i.Task.Title, i.Task.CreatedAt.Format("2006-01-02 15:04"))
+	todayMark := ""
+	if i.Task.IsToday() {
+		todayMark = "📌 "
+	}
+	return fmt.Sprintf("%s%s %s%s  created_at: %s", i.Prefix, check, todayMark, i.Task.Title, i.Task.CreatedAt.Format("2006-01-02 15:04"))
 }
 
 func (i TaskItem) Description() string {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -33,6 +33,7 @@ type extraKeyMap struct {
 	SubAdd key.Binding
 	Toggle key.Binding
 	Delete key.Binding
+	Today  key.Binding
 }
 
 func newExtraKeyMap() extraKeyMap {
@@ -52,6 +53,10 @@ func newExtraKeyMap() extraKeyMap {
 		Delete: key.NewBinding(
 			key.WithKeys("d"),
 			key.WithHelp("d", "delete"),
+		),
+		Today: key.NewBinding(
+			key.WithKeys("t"),
+			key.WithHelp("t", "today"),
 		),
 	}
 }
@@ -91,10 +96,10 @@ func NewModel(s *store.TaskStore) Model {
 	l.SetFilteringEnabled(true)
 	l.SetStatusBarItemName("task", "tasks")
 	l.AdditionalShortHelpKeys = func() []key.Binding {
-		return []key.Binding{keys.Add, keys.SubAdd, keys.Toggle, keys.Delete}
+		return []key.Binding{keys.Add, keys.SubAdd, keys.Toggle, keys.Delete, keys.Today}
 	}
 	l.AdditionalFullHelpKeys = func() []key.Binding {
-		return []key.Binding{keys.Add, keys.SubAdd, keys.Toggle, keys.Delete}
+		return []key.Binding{keys.Add, keys.SubAdd, keys.Toggle, keys.Delete, keys.Today}
 	}
 
 	return Model{
@@ -175,6 +180,14 @@ func (m Model) updateList(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter", "x":
 			if item, ok := m.list.SelectedItem().(TaskItem); ok {
 				if err := m.store.ToggleComplete(item.Task.ID); err != nil {
+					m.err = err
+					return m, nil
+				}
+				return m, m.loadTasks
+			}
+		case "t":
+			if item, ok := m.list.SelectedItem().(TaskItem); ok {
+				if err := m.store.ToggleToday(item.Task.ID); err != nil {
 					m.err = err
 					return m, nil
 				}


### PR DESCRIPTION
## Summary
- タスクに「今日やる」マーキング機能を追加
- `t` キーで 📌 マークをトグル（`scheduled_on` カラムに今日の日付をセット）
- 日付が変わるとマークは自動的に解除される（DB クリーンアップ不要）

## Changes
- `internal/model/task.go`: `ScheduledOn` フィールドと `IsToday()` メソッド追加
- `internal/store/store.go`: `scheduled_on` カラムのマイグレーション、`ToggleToday()` メソッド、SELECT文更新
- `internal/ui/item.go`: タスク名の前に 📌 インジケータ表示
- `internal/ui/ui.go`: `t` キーバインド追加

## Test plan
- [ ] `go build ./...` が成功すること
- [ ] タスク選択 → `t` で 📌 マークがトグルされること
- [ ] 再起動後もマーク状態が維持されること
- [ ] 既存DBからの起動でマイグレーションが動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)