### PR TITLE
feat: add split-pane layout with task detail panel

### DIFF
--- a/internal/ui/item.go
+++ b/internal/ui/item.go
@@ -24,7 +24,7 @@ func (i TaskItem) Title() string {
 	if i.Task.IsToday() {
 		todayMark = "📌 "
 	}
-	return fmt.Sprintf("%s%s %s%s  created_at: %s", i.Prefix, check, todayMark, i.Task.Title, i.Task.CreatedAt.Format("2006-01-02 15:04"))
+	return fmt.Sprintf("%s%s %s%s", i.Prefix, check, todayMark, i.Task.Title)
 }
 
 func (i TaskItem) Description() string {


### PR DESCRIPTION
## Summary

- 画面を左右2分割（左60% タスクリスト / 右40% 詳細ペイン）のレイアウトに変更
- タスクリストの `Title()` から `created_at` を削除してコンパクトに表示
- 右ペインに選択中タスクの詳細（タスク名、created_at、📌マーク）を表示

## Test plan

- [ ] `go build ./...` が成功すること
- [ ] タスクリストでカーソル移動 → 右ペインの詳細がリアルタイム追従すること
- [ ] 📌 マーク付きタスクは右ペインにも 📌 表示されること
- [ ] `a` キーで追加画面、`d` キーで確認画面 → 2分割ではなく従来の全画面表示になること
- [ ] ウィンドウリサイズで左右ペインが追従すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)