### PR TITLE
feat: add tag system with colored badges

### DIFF
--- a/internal/model/task.go
+++ b/internal/model/task.go
@@ -2,6 +2,13 @@ package model
 
 import "time"
 
+// Tag represents a reusable label that can be attached to tasks.
+type Tag struct {
+	ID    int
+	Name  string
+	Color string // lipgloss 256-color code, e.g. "205", "39", "148"
+}
+
 // Task represents a single task stored in the database.
 type Task struct {
 	ID          int
@@ -12,6 +19,7 @@ type Task struct {
 	CreatedAt   time.Time
 	ScheduledOn *string
 	DueDate     *string
+	Tags        []Tag
 }
 
 // IsToday returns true if the task is scheduled for today.

--- a/internal/ui/item.go
+++ b/internal/ui/item.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/nissyi-gh/flow/internal/model"
 )
 
@@ -30,7 +31,16 @@ func (i TaskItem) Title() string {
 	} else if i.Task.IsDueToday() {
 		dueMark = "📅 "
 	}
-	return fmt.Sprintf("%s%s %s%s%s", i.Prefix, check, dueMark, todayMark, i.Task.Title)
+	title := fmt.Sprintf("%s%s %s%s%s", i.Prefix, check, dueMark, todayMark, i.Task.Title)
+
+	for _, tag := range i.Task.Tags {
+		badge := lipgloss.NewStyle().
+			Foreground(lipgloss.Color(tag.Color)).
+			Render("[" + tag.Name + "]")
+		title += " " + badge
+	}
+
+	return title
 }
 
 func (i TaskItem) Description() string {


### PR DESCRIPTION
## Summary

- タスクにタグ（ラベル）を付けて分類・整理できるようにする機能を追加
- `tags` / `task_tags` テーブルによる多対多リレーション
- `T` キーでタグ選択画面を表示し、既存タグのトグルや新規タグ作成が可能
- タスクリストと詳細パネルに8色パレットの色付きバッジで表示

## 変更内容

- **Model**: `Tag` 構造体（ID, Name, Color）追加、`Task.Tags []Tag` フィールド追加
- **Store**: `migrateTags()` で tags/task_tags テーブル作成、タグ CRUD メソッド（CreateTag, ListTags, DeleteTag, AssignTag, UnassignTag, TagsForTask）、`List()` / `GetByID()` でタグ自動読み込み
- **UI**: `stateTagSelect` ステート、`T` キーバインド、タグ選択 UI（j/k 移動、enter/space トグル、`+ New tag...` で新規作成）、リスト項目・詳細パネルでの色付きバッジ表示

## 操作方法

1. リスト画面でタスク選択 → `T` キー → タグ選択画面
2. `j/k` で移動、`enter/space` で付け外しトグル
3. 末尾の `+ New tag...` で新規タグを作成（自動付与）
4. `esc` でリストに戻る

## Test plan

- [ ] `go build ./...` でビルド確認
- [ ] `T` キーでタグ選択画面が表示される（初回は `+ New tag...` のみ）
- [ ] 新規タグを作成 → 自動付与されリスト・詳細パネルに色付きバッジ表示
- [ ] 既存タグのトグル（付与/解除）が正常動作
- [ ] タグ付きタスクを削除 → task_tags も CASCADE 削除される
- [ ] 複数タグを付与した場合、それぞれ異なる色で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)