### PR TITLE
feat: add AI task breakdown with YAML import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module github.com/nissyi-gh/flow
 go 1.25.0
 
 require (
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.45.0
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
@@ -76,6 +78,10 @@ golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
 golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.27.1 h1:9W30zRlYrefrDV2JE2O8VDtJ1yPGownxciz5rrbQZis=
 modernc.org/cc/v4 v4.27.1/go.mod h1:uVtb5OGqUKpoLWhqwNQo/8LwvoiEBLvZXIQ/SmO6mL0=
 modernc.org/ccgo/v4 v4.30.1 h1:4r4U1J6Fhj98NKfSjnPUN7Ze2c6MnAdL0hWw6+LrJpc=

--- a/internal/importer/yaml.go
+++ b/internal/importer/yaml.go
@@ -1,0 +1,120 @@
+package importer
+
+import (
+	"fmt"
+
+	"github.com/nissyi-gh/flow/internal/store"
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLTask represents a single task in the YAML input.
+type YAMLTask struct {
+	Title       string     `yaml:"title"`
+	Description string     `yaml:"description,omitempty"`
+	DueDate     string     `yaml:"due_date,omitempty"`
+	Tags        []string   `yaml:"tags,omitempty"`
+	Children    []YAMLTask `yaml:"children,omitempty"`
+}
+
+// YAMLInput represents the root structure of the YAML input.
+type YAMLInput struct {
+	Tasks []YAMLTask `yaml:"tasks"`
+}
+
+// Import parses a YAML string and creates tasks in the store.
+// parentID can be nil for root-level tasks.
+// Returns the number of tasks created.
+func Import(s *store.TaskStore, yamlStr string, parentID *int) (int, error) {
+	var input YAMLInput
+	if err := yaml.Unmarshal([]byte(yamlStr), &input); err != nil {
+		return 0, fmt.Errorf("YAML parse error: %w", err)
+	}
+
+	if len(input.Tasks) == 0 {
+		return 0, fmt.Errorf("no tasks found in YAML")
+	}
+
+	count := 0
+	for _, yt := range input.Tasks {
+		n, err := importTask(s, yt, parentID)
+		if err != nil {
+			return count, err
+		}
+		count += n
+	}
+	return count, nil
+}
+
+func importTask(s *store.TaskStore, yt YAMLTask, parentID *int) (int, error) {
+	if yt.Title == "" {
+		return 0, fmt.Errorf("task title is required")
+	}
+
+	task, err := s.Add(yt.Title, parentID)
+	if err != nil {
+		return 0, fmt.Errorf("add task %q: %w", yt.Title, err)
+	}
+	count := 1
+
+	if yt.Description != "" {
+		desc := yt.Description
+		if err := s.UpdateDescription(task.ID, &desc); err != nil {
+			return count, fmt.Errorf("set description for %q: %w", yt.Title, err)
+		}
+	}
+
+	if yt.DueDate != "" {
+		dd := yt.DueDate
+		if err := s.SetDueDate(task.ID, &dd); err != nil {
+			return count, fmt.Errorf("set due date for %q: %w", yt.Title, err)
+		}
+	}
+
+	if len(yt.Tags) > 0 {
+		if err := assignTags(s, task.ID, yt.Tags); err != nil {
+			return count, fmt.Errorf("assign tags for %q: %w", yt.Title, err)
+		}
+	}
+
+	for _, child := range yt.Children {
+		id := task.ID
+		n, err := importTask(s, child, &id)
+		if err != nil {
+			return count, err
+		}
+		count += n
+	}
+
+	return count, nil
+}
+
+func assignTags(s *store.TaskStore, taskID int, tagNames []string) error {
+	existingTags, err := s.ListTags()
+	if err != nil {
+		return err
+	}
+
+	tagMap := make(map[string]int)
+	for _, t := range existingTags {
+		tagMap[t.Name] = t.ID
+	}
+
+	palette := []string{"39", "205", "148", "214", "141", "81", "203", "227"}
+
+	for _, name := range tagNames {
+		tagID, exists := tagMap[name]
+		if !exists {
+			color := palette[len(tagMap)%len(palette)]
+			tag, err := s.CreateTag(name, color)
+			if err != nil {
+				return fmt.Errorf("create tag %q: %w", name, err)
+			}
+			tagID = tag.ID
+			tagMap[name] = tagID
+		}
+		if err := s.AssignTag(taskID, tagID); err != nil {
+			return fmt.Errorf("assign tag %q: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/internal/prompt/generate.go
+++ b/internal/prompt/generate.go
@@ -1,0 +1,81 @@
+package prompt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nissyi-gh/flow/internal/model"
+)
+
+const yamlFormat = `以下のYAMLフォーマットで出力してください。YAMLのコードブロックのみを出力し、それ以外の文章は含めないでください。
+
+` + "```yaml" + `
+tasks:
+  - title: "タスク名"
+    description: "タスクの詳細説明"
+    due_date: "YYYY-MM-DD"
+    tags:
+      - "タグ名"
+    children:
+      - title: "子タスク名"
+        description: "子タスクの説明"
+` + "```" + `
+
+フィールドの説明:
+- title: (必須) タスクのタイトル
+- description: (任意) タスクの詳細な説明
+- due_date: (任意) 期限日 (YYYY-MM-DD形式)
+- tags: (任意) タグのリスト
+- children: (任意) 子タスクのリスト (再帰的にネスト可能)`
+
+// GenerateNew returns a prompt for creating new tasks from scratch.
+func GenerateNew() string {
+	return fmt.Sprintf(`あなたはタスク管理のアシスタントです。
+ユーザーの要求に基づいて、タスクを適切な粒度に分解してください。
+
+%s
+`, yamlFormat)
+}
+
+// GenerateFromTask returns a prompt for breaking down an existing task.
+func GenerateFromTask(task model.Task, children []model.Task) string {
+	var sb strings.Builder
+
+	sb.WriteString("あなたはタスク管理のアシスタントです。\n")
+	sb.WriteString("以下の既存タスクをより具体的な子タスクに分解してください。\n\n")
+
+	sb.WriteString("## 対象タスク\n")
+	sb.WriteString(fmt.Sprintf("- タイトル: %s\n", task.Title))
+
+	if task.Description != nil && *task.Description != "" {
+		sb.WriteString(fmt.Sprintf("- 説明: %s\n", *task.Description))
+	}
+	if task.DueDate != nil {
+		sb.WriteString(fmt.Sprintf("- 期限: %s\n", *task.DueDate))
+	}
+	if len(task.Tags) > 0 {
+		var tagNames []string
+		for _, t := range task.Tags {
+			tagNames = append(tagNames, t.Name)
+		}
+		sb.WriteString(fmt.Sprintf("- タグ: %s\n", strings.Join(tagNames, ", ")))
+	}
+
+	if len(children) > 0 {
+		sb.WriteString("\n## 既存の子タスク\n")
+		for _, c := range children {
+			status := "未完了"
+			if c.Completed {
+				status = "完了"
+			}
+			sb.WriteString(fmt.Sprintf("- %s (%s)\n", c.Title, status))
+		}
+		sb.WriteString("\n上記の既存子タスクを考慮した上で、不足している子タスクを追加してください。\n")
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(yamlFormat)
+	sb.WriteString("\n")
+
+	return sb.String()
+}


### PR DESCRIPTION
## Summary
- AIにタスク分解を依頼するためのプロンプト生成機能を追加 (`g` キー)
- クリップボードからYAMLをインポートしてタスクを一括登録する機能を追加 (`G` キー)
- インポート時にルートタスク or 既存タスクの子タスクとして登録するか選択可能

## Test plan
- [ ] `g` キーで選択画面が表示されること
- [ ] 「新しいタスクを分解する」でプロンプトがクリップボードにコピーされること
- [ ] 「既存タスクを改善する」で選択中タスクの情報を含むプロンプトがコピーされること
- [ ] AIが生成したYAMLをコピーし `G` キーでインポート先選択画面が表示されること
- [ ] 「ルートタスクとしてインポート」で親なしタスクが登録されること
- [ ] 「子タスクとしてインポート」で選択中タスクの配下に登録されること
- [ ] ネスト構造(children)のYAMLが正しくツリー構造で登録されること
- [ ] タグが未存在の場合に自動作成されること
- [ ] コードブロック(```yaml```)付きYAMLが正しく処理されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)